### PR TITLE
add subtle.ConstantTimeCompare to Verify Bytes comparison

### DIFF
--- a/xmss.go
+++ b/xmss.go
@@ -1,8 +1,8 @@
 package xmss
 
 import (
-	"bytes"
 	"crypto/rand"
+	"crypto/subtle"
 )
 
 // Section 4.1.5. Algorithm 8: ltree
@@ -268,7 +268,7 @@ func Verify(params *Params, m, signature []byte, pub PublicXMSS) (match bool) {
 	}
 
 	// Check if the root node equals the root node in the public key
-	if !bytes.Equal(root, pubRoot) {
+	if subtle.ConstantTimeCompare(root, pubRoot) == 0 {
 		// Zero the message
 		copy(m[params.signBytes:], make([]byte, msgLen))
 		match = false


### PR DESCRIPTION
### Proposal
replace `bytes.Equal` with  `subtle.ConstantTimeCompare` for root node comparison on user facing `Verify` method. This is simply to ensure no timing attack leaks occur on the byte comparison.

It ended up being a single like replacement and a new library import. I also ran

```go test -v``` with this change and the tests passed.

```bash
➜  go-xmss git:(subtle-verify) ✗ go test -v
=== RUN   TestWOTS
WOTS+ test successful.
--- PASS: TestWOTS (0.01s)
=== RUN   TestSHA2_10_256
Testing SHA2_10_256
XMSS signature matches.
Flipping a bit correctly invalides the XMSS signature.
XMSS signature updated the private key's index.
--- PASS: TestSHA2_10_256 (4.80s)
=== RUN   TestSHA2_16_256
Testing SHA2_16_256
XMSS signature matches.
Flipping a bit correctly invalides the XMSS signature.
XMSS signature updated the private key's index.
--- PASS: TestSHA2_16_256 (314.50s)
PASS
```